### PR TITLE
Plan, acciones y predicado de usar canon de agua

### DIFF
--- a/src/rescate/ontologia/acciones/DannarPared.java
+++ b/src/rescate/ontologia/acciones/DannarPared.java
@@ -7,7 +7,7 @@ public class DannarPared extends Accion {
   private Casilla casilla;
   private int conexion;
 
-  public DerribarPared() {
+  public DannarPared() {
   }
 
   public Casilla getCasilla() {

--- a/src/rescate/ontologia/acciones/UsarCannonAgua.java
+++ b/src/rescate/ontologia/acciones/UsarCannonAgua.java
@@ -1,8 +1,0 @@
-package rescate.ontologia.acciones;
-
-public class UsarCannonAgua extends Accion {
-
-  public UsarCannonAgua() {
-  }
-
-}

--- a/src/rescate/ontologia/acciones/UsarCannonAguaAccion.java
+++ b/src/rescate/ontologia/acciones/UsarCannonAguaAccion.java
@@ -1,0 +1,8 @@
+package rescate.ontologia.acciones;
+
+public class UsarCannonAguaAccion extends Accion {
+
+  public UsarCannonAguaAccion() {
+  }
+
+}

--- a/src/rescate/ontologia/conceptos/Tablero.java
+++ b/src/rescate/ontologia/conceptos/Tablero.java
@@ -49,6 +49,10 @@ public class Tablero extends Concepto {
     return mapa;
   }
 
+  public void setMapa(Casilla[][]mapa){
+    this.mapa=mapa;
+  }
+
   public void setCasilla(int X, int Y, Casilla c) {
     this.mapa[Y][X] = c;
   }

--- a/src/rescate/ontologia/predicados/CanonUsadoPredicado.java
+++ b/src/rescate/ontologia/predicados/CanonUsadoPredicado.java
@@ -1,0 +1,8 @@
+package rescate.ontologia.predicados;
+
+public class CanonUsadoPredicado extends Predicado {
+
+  public CanonUsadoPredicado() {
+  }
+
+}

--- a/src/rescate/ontologia/predicados/ParedDannada.java
+++ b/src/rescate/ontologia/predicados/ParedDannada.java
@@ -1,8 +1,8 @@
 package rescate.ontologia.predicados;
 
-public class ParedRota extends Predicado {
+public class ParedDannada extends Predicado {
 
-  public ParedRota() {
+  public ParedDannada() {
   }
 
 }

--- a/src/rescate/tablero/planes/MontarEnVehiculoPlan.java
+++ b/src/rescate/tablero/planes/MontarEnVehiculoPlan.java
@@ -10,11 +10,54 @@ import rescate.ontologia.acciones.*;
 import rescate.ontologia.conceptos.*;
 import rescate.ontologia.predicados.*;
 
-class MontarEnVehiculoPlan extends Plan {
+public class MontarEnVehiculoPlan extends Plan {
 
-  @Override
-  public void body() {
+    @Override
+    public void body() {
 
-  }
+        System.out.println("tablero recibe peticion subir a vehiculo...");
+        IMessageEvent request = (IMessageEvent) getInitialEvent();
+        //TODO Obtener Jugador del mensaje.
+        Jugador jugador = (Jugador) request.getParameter("emisor").getValue();
+        Boolean camionOAmbulancia = (Boolean) request.getParameter("camionOAmbulancia").getValue();
+
+        //Get Ambulancia
+        Ambulancia ambulancia = (Ambulancia) getBeliefbase().getBelief("ambulancia").getFact();
+        //Get Camion Bomberos
+        CamionBomberos camionBomberos = (CamionBomberos) getBeliefbase().getBelief("camionBomberos").getFact();
+
+        getBeliefbase().getBeliefSet("ambulancia").removeFact(ambulancia);
+        getBeliefbase().getBeliefSet("camionBomberos").removeFact(camionBomberos);
+
+        List<Jugador> jugadoresEnAmbulancia = ambulancia.getJugadoresEnVehiculo();
+        List<Jugador> jugadoresEnCamion = camionBomberos.getJugadoresEnVehiculo();
+
+        int[] posicionAmbulancia = ambulancia.getPosicion();
+        int[] posicionCamionBomberos = camionBomberos.getPosicion();
+        int[] posicionJugador = jugador.getPosicion();
+
+        //Si camionOAmbulancia ==1 peticion para ir a ambulancia, si es 0 es para ir a camion.
+        if (camionOAmbulancia) {
+            jugadoresEnAmbulancia.add(jugador);
+            posicionJugador = posicionAmbulancia;
+            jugador.setPosicion(posicionJugador);
+
+        } else {
+            jugadoresEnCamion.add(jugador);
+            posicionJugador = posicionCamionBomberos;
+            jugador.setPosicion(posicionJugador);
+        }
+
+        ambulancia.setJugadoresEnVehiculo(jugadoresEnAmbulancia);
+        camionBomberos.setJugadoresEnVehiculo(jugadoresEnCamion);
+
+
+        getBeliefbase().getBeliefSet("ambulancia").addFact(ambulancia);
+        getBeliefbase().getBeliefSet("camionBomberos").addFact(camionBomberos);
+        //TODO Añadir a la base de creencias al jugador.
+
+
+    }
+
 
 }

--- a/src/rescate/tablero/planes/UsarCanonDeAguaPlan.java
+++ b/src/rescate/tablero/planes/UsarCanonDeAguaPlan.java
@@ -8,6 +8,7 @@ import jadex.runtime.Plan;
 
 import rescate.ontologia.acciones.*;
 import rescate.ontologia.conceptos.*;
+import rescate.ontologia.conceptos.Casilla.Conexion;
 import rescate.ontologia.predicados.*;
 
 class UsarCanonDeAguaPlan extends Plan {
@@ -15,6 +16,121 @@ class UsarCanonDeAguaPlan extends Plan {
   @Override
   public void body() {
 
+    System.out.println("[PLAN] El tablero recibe petición de usar el cañón de agua");
+    CanonUsadoPredicado cu = new CanonUsadoPredicado();
+    
+    // Petición
+    IMessageEvent peticion = (IMessageEvent) getInitialEvent();
+
+    // Tablero
+    Tablero tablero = (Tablero) getBeliefbase().getBelief("tablero").getFact();
+
+    // Parámetros de la peticion
+    AgentIdentifier idJugador = (AgentIdentifier) peticion.getParameter("sender").getValue();
+
+    // Se encuentra en la lista de jugadores del tablero el jugador con id igual al de la petición
+    Jugador jugador = tablero.getJugador(idJugador);
+
+    // Casilla en la que está el jugador
+
+    boolean usado = false;
+
+    IMessageEvent msg = createMessageEvent("Agree_Usar_Canon");
+
+    if(jugador.subidoCamion() && (jugador.getPuntosAccion() > 4 || (jugador.getRol() == Jugador.Rol.CONDUCTOR && jugador.getPuntosAccion() > 2))){
+      
+      int posicionCanonX;
+      int posicionCanonY;
+
+      Casilla[][] mapa = tablero.getMapa();
+
+      if (jugador.getPosicion()[1] == 0) {
+        //Cuadrante de arriba-derecha
+        posicionCanonX = (int)(Math.random() * 4 + 5);// entre 5 y 8
+        posicionCanonY = (int)(Math.random() * 3 + 1);// entre 1 y 3
+        
+        Casilla[][] nuevoMapa = apagarAdyacentes(mapa, posicionCanonX, posicionCanonY);
+
+        tablero.setMapa(nuevoMapa);
+      }else if(jugador.getPosicion()[1] == mapa.length-1){
+        //Cuadrante de abajo-izquierda
+        posicionCanonX = (int)(Math.random() * 4 + 1);// entre 1 y 4
+        posicionCanonY = (int)(Math.random() * 3 + 4);// entre 4 y 6
+        
+        Casilla[][] nuevoMapa = apagarAdyacentes(mapa, posicionCanonX, posicionCanonY);
+
+        tablero.setMapa(nuevoMapa);
+      }else if(jugador.getPosicion()[0] == 0){
+        //Cuadrante de arriba-izquierda
+        posicionCanonX = (int)(Math.random() * 4 + 1);// entre 1 y 4
+        posicionCanonY = (int)(Math.random() * 3 + 1);// entre 1 y 3
+        
+        Casilla[][] nuevoMapa = apagarAdyacentes(mapa, posicionCanonX, posicionCanonY);
+
+        tablero.setMapa(nuevoMapa);
+      }else if(jugador.getPosicion()[0] == mapa[0].length-1){
+        //Cuadrante de abajo-derecha
+        posicionCanonX = (int)(Math.random() * 4 + 5);// entre 5 y 8
+        posicionCanonY = (int)(Math.random() * 3 + 4);// entre 4 y 6
+        
+        Casilla[][] nuevoMapa = apagarAdyacentes(mapa, posicionCanonX, posicionCanonY);
+
+        tablero.setMapa(nuevoMapa);
+      }else{
+        //debe se imposible
+      }
+
+      usado = true;
+    }
+
+    
+
+		if (!usado) {
+      msg = createMessageEvent("Refuse_Usar_Canon");
+      if(!jugador.subidoCamion()){
+        System.out.println("tablero deniega peticion de usar cañon: el jugador no está subido al camión");
+      }
+      if(!(jugador.getPuntosAccion() > 4 || (jugador.getRol() == Jugador.Rol.CONDUCTOR && jugador.getPuntosAccion() > 2))){
+        System.out.println("tablero deniega peticion de usar cañon: el jugador no tiene suficientes PA");
+      }
+    }else{
+      getBeliefbase().getBelief("tablero").setFact(tablero);
+      System.out.println("tablero informa que se ha usado el cañon de agua");
+    }
+    
+    msg.setContent(cu);
+    msg.getParameterSet(SFipa.RECEIVERS).addValue(idJugador);
+    sendMessage(msg);
+
+  }
+
+
+  public Casilla[][] apagarAdyacentes(Casilla[][] mapa, int posX, int posY){
+
+    Casilla casilla = mapa[posY][posX];
+    Conexion[] conexiones =  casilla.getConexiones();
+
+    casilla.setTieneFuego(Casilla.Fuego.NADA);
+
+    //Casilla adyacente arriba
+    if(conexiones[0] == Casilla.Conexion.NADA || conexiones[0] == Casilla.Conexion.PUERTA_ABIERTA || conexiones[0] == Casilla.Conexion.PARED_ROTA){
+      mapa[posY-1][posX].setTieneFuego(Casilla.Fuego.NADA);
+    }
+    //Casilla adyacente abajo
+    if(conexiones[2] == Casilla.Conexion.NADA || conexiones[2] == Casilla.Conexion.PUERTA_ABIERTA || conexiones[2] == Casilla.Conexion.PARED_ROTA){
+      mapa[posY+1][posX].setTieneFuego(Casilla.Fuego.NADA);
+    }
+    //Casilla adyacente derecha
+    if(conexiones[1] == Casilla.Conexion.NADA || conexiones[1] == Casilla.Conexion.PUERTA_ABIERTA || conexiones[1] == Casilla.Conexion.PARED_ROTA){
+      mapa[posY][posX+1].setTieneFuego(Casilla.Fuego.NADA);
+    }
+    //Casilla adyacente izquierda
+    if(conexiones[3] == Casilla.Conexion.NADA || conexiones[3] == Casilla.Conexion.PUERTA_ABIERTA || conexiones[3] == Casilla.Conexion.PARED_ROTA){
+      mapa[posY][posX-1].setTieneFuego(Casilla.Fuego.NADA);
+    }
+
+    return mapa;
   }
 
 }
+

--- a/src/rescate/tablero/tablero.agent.xml
+++ b/src/rescate/tablero/tablero.agent.xml
@@ -705,14 +705,45 @@
       </messageevent>
 
 
-      <messageevent name="Request_Conducir_Camion" direction="send" type="fipa">
-      </messageevent>
-
-
       <messageevent name="Request_Desplazar_ambulancia" direction="send" type="fipa">
       </messageevent>
-      <messageevent name="Request_Usar_canon_de_agua" direction="send" type="fipa">
+      
+      <messageevent name="Request_Usar_canon_de_agua" direction="receive" type="fipa">
+        <parameter name="performative" class="String" direction="fixed">
+          <value>SFipa.REQUEST</value>
+        </parameter>
+        <parameter name="language" class="String" direction="fixed">
+          <value>SFipa.NUGGETS_XML</value>
+        </parameter>
+        <parameter name="content-class" class="Class" direction="fixed">
+          <value>UsarCanonDeAguaAccion.class</value>
+        </parameter>
       </messageevent>
+
+      <messageevent name="Agree_Usar_Canon" direction="send" type="fipa">
+        <parameter name="performative" class="String" direction="fixed">
+          <value>SFipa.AGREE</value>
+        </parameter>
+        <parameter name="language" class="String" direction="fixed">
+          <value>SFipa.NUGGETS_XML</value>
+        </parameter>
+        <parameter name="content-class" class="Class" direction="fixed">
+          <value>CanonUsadoPredicado.class</value>
+        </parameter>
+      </messageevent>
+
+      <messageevent name="Refuse_Usar_Canon" direction="send" type="fipa">
+        <parameter name="performative" class="String" direction="fixed">
+          <value>SFipa.FAILURE</value>
+        </parameter>
+        <parameter name="language" class="String" direction="fixed">
+          <value>SFipa.NUGGETS_XML</value>
+        </parameter>
+        <parameter name="content-class" class="Class" direction="fixed">
+          <value>CanonUsadoPredicado.class</value>
+        </parameter>
+      </messageevent>
+
       <messageevent name="Request_Mando" direction="send" type="fipa">
       </messageevent>
       <messageevent name="Request_Eliminar_materia_peligrosa" direction="send" type="fipa">


### PR DESCRIPTION
He añadido el plan de usar cañon de agua, además del de montar camión. Pero hay conflictos que hay que arreglar para el plan de propagarFuego y montar camión.

Propagar fuego utiliza la nomenclatura anterior de posiciones para el mapa, y montar camión tiene los conceptos de ambulancia y camión que no deberían estar.

He añadido también al xml los requests agree y refuse de usar el cañon.