### PR TITLE
Commit descubrir PDI y usar canon de agua

### DIFF
--- a/src/rescate/ontologia/conceptos/Casilla.java
+++ b/src/rescate/ontologia/conceptos/Casilla.java
@@ -8,7 +8,7 @@ public class Casilla extends Concepto {
 	}
 
 	public enum PuntoInteres {
-		NADA, OCULTO, FALSA_ALARMA, VICTIMA, VICTIMA_CURADA
+		NADA, OCULTO, VICTIMA_OCULTO, FALSA_ALARMA_OCULTO, FALSA_ALARMA, VICTIMA, VICTIMA_CURADA
 	}
 
 	public enum Direccion {
@@ -29,18 +29,18 @@ public class Casilla extends Concepto {
 
 	private Fuego tieneFuego;
 	private boolean tieneMateriaPeligrosa;
-  private boolean tieneFocoCalor;
+    private boolean tieneFocoCalor;
 
-  private PuntoInteres puntoInteres;
+    private PuntoInteres puntoInteres;
   
 	private Direccion flecha;
 
 	private boolean camionBomberos;
 	private boolean ambulancia;
 	private boolean esAparcamientoCamion;
-  private boolean esAparcamientoAmbulancia;
+    private boolean esAparcamientoAmbulancia;
   
-  private int habitacion;
+    private int habitacion;
 
 	/*** Getters & Setters ***/
 	public int[] getPosicion() {

--- a/src/rescate/ontologia/conceptos/Tablero.java
+++ b/src/rescate/ontologia/conceptos/Tablero.java
@@ -49,6 +49,10 @@ public class Tablero extends Concepto {
     return mapa;
   }
 
+  public void setMapa(Casilla[][] mapa){
+    this.mapa=mapa;
+  }
+
   public void setCasilla(int X, int Y, Casilla c) {
     this.mapa[Y][X] = c;
   }

--- a/src/rescate/ontologia/predicados/CannonUsado.java
+++ b/src/rescate/ontologia/predicados/CannonUsado.java
@@ -1,0 +1,8 @@
+package rescate.ontologia.predicados;
+
+public class CannonUsado extends Predicado {
+
+  public CannonUsado() {
+  }
+
+}

--- a/src/rescate/ontologia/predicados/CanonUsado.java
+++ b/src/rescate/ontologia/predicados/CanonUsado.java
@@ -1,0 +1,8 @@
+package rescate.ontologia.predicados;
+
+public class CanonUsado extends Predicado {
+
+  public CanonUsado() {
+  }
+
+}

--- a/src/rescate/ontologia/predicados/CanonUsado.java
+++ b/src/rescate/ontologia/predicados/CanonUsado.java
@@ -1,8 +1,0 @@
-package rescate.ontologia.predicados;
-
-public class CanonUsado extends Predicado {
-
-  public CanonUsado() {
-  }
-
-}

--- a/src/rescate/ontologia/predicados/MateriaPeligrosaEliminada.java
+++ b/src/rescate/ontologia/predicados/MateriaPeligrosaEliminada.java
@@ -1,0 +1,9 @@
+package rescate.ontologia.predicados;
+
+public class MateriaPeligrosaEliminada extends Predicado {
+
+  public MateriaPeligrosaEliminada() {
+    
+  }
+
+}

--- a/src/rescate/tablero/planes/EliminarMateriaPeligrosaPlan.java
+++ b/src/rescate/tablero/planes/EliminarMateriaPeligrosaPlan.java
@@ -14,9 +14,52 @@ class EliminarMateriaPeligrosaPlan extends Plan {
 
   @Override
   public void body() {
+	    System.out.println("[PLAN] tablero recibe peticion de eliminar matera peligrosa...");
+		IMessageEvent request = (IMessageEvent) getInitialEvent();
+		AgentIdentifier jugadorId = (AgentIdentifier) request.getParameter("emisor").getValue();
+		Casilla casillaSolicitada = (Casilla) request.getParameter("casilla").getValue();
+		MateriaPeligrosaEliminada mpep = new MateriaPeligrosaEliminada();
 
-    
+		boolean ok = false;
+		Jugador jugador = new Jugador();
+		Tablero tablero = (Tablero) getBeliefbase().getBelief("tablero").getFact();
 
+		for (int i = 0; i < tablero.getJugadores().size(); i++) {
+			if (tablero.getJugadores().get(i).getIdAgente().equals(jugadorId)) {
+				jugador = tablero.getJugadores().get(i);
+			}
+		}
+		if (casillaSolicitada.tieneMateriaPeligrosa() == true && (jugador.getPuntosAccion() >= 2 && jugador.getRol() == Jugador.Rol.MATERIAS_PELIGROSAS)) { 																									
+			ok = true;
+		}
+
+
+
+	    IMessageEvent msg = createMessageEvent("Agree_Eliminar_Materia");
+		if (!ok) {
+			msg = createMessageEvent("Refuse_Eliminar_Materia");
+			System.out.println("[RECHAZADO] tablero deniega peticion de eliminar materia peligrosa: la casilla no tiene materia peligrosa");
+		} else {
+
+	    Casilla[][] mapa = tablero.getMapa();
+
+	    for(int i=0; i< mapa.length; i++){
+	       for(int j=0; j< mapa[0].length; j++){
+	         if(mapa[i][j].equals(casillaSolicitada)){
+	           mapa[i][j].setTieneMateriaPeligrosa(false);
+	         }
+	       }
+	     }
+
+	     tablero.setMapa(mapa);
+
+	     getBeliefbase().getBelief("tablero").setFact(tablero);
+	     System.out.println("[INFO] tablero informa que la materia peligrosa ha sido eliminada");
+
+	    }
+	    msg.setContent(mpep);
+	    msg.getParameterSet(SFipa.RECEIVERS).addValue(jugadorId);
+	    sendMessage(msg);
   }
 
 }

--- a/src/rescate/tablero/planes/MoverJugadorPlan.java
+++ b/src/rescate/tablero/planes/MoverJugadorPlan.java
@@ -69,10 +69,29 @@ class MoverJugadorPlan extends Plan {
     else {
       if (jugador.getPuntosAccion() + jugador.getPuntosAccionMovimiento() >= puntosAccionNecesarios(destino, jugador)) {
         jugador.setPosicion(destino.getPosicion());
+        if(destino.getPuntoInteres()==Casilla.PuntoInteres.VICTIMA_OCULTO){
+          destino.setPuntoInteres(Casilla.PuntoInteres.VICTIMA);
+        }else if (destino.getPuntoInteres()==Casilla.PuntoInteres.FALSA_ALARMA_OCULTO){
+          destino.setPuntoInteres(Casilla.PuntoInteres.FALSA_ALARMA);
+        }
+        getBeliefbase().getBelief("tablero").setFact(t);
+
+        System.out.println("[INFO] El jugador con id " + idJugador + " se ha desplazado a la casilla" + destino.getPosicion()[0] + " , "+ destino.getPosicion()[1]);
+        // Se rechaza la petición de acción del jugador
+        IMessageEvent respuesta = createMessageEvent("Inform_Desplazar");
+        respuesta.setContent(new Desplazado());
+        respuesta.getParameterSet(SFipa.RECEIVERS).addValue(idJugador);
+        sendMessage(respuesta);
       }
       else {
-
+        System.out.println("[RECHAZADO] El jugador con id " + idJugador + " no tiene PA suficientes para desplazarse");
+        // Se rechaza la petición de acción del jugador
+        IMessageEvent respuesta = createMessageEvent("Refuse_Desplazar");
+        respuesta.setContent(accion);
+        respuesta.getParameterSet(SFipa.RECEIVERS).addValue(idJugador);
+        sendMessage(respuesta);
       }
+      
     }
 
   }

--- a/src/rescate/tablero/planes/UsarCannonDeAguaPlan.java
+++ b/src/rescate/tablero/planes/UsarCannonDeAguaPlan.java
@@ -8,13 +8,128 @@ import jadex.runtime.Plan;
 
 import rescate.ontologia.acciones.*;
 import rescate.ontologia.conceptos.*;
+import rescate.ontologia.conceptos.Casilla.Conexion;
 import rescate.ontologia.predicados.*;
 
-class UsarCannonDeAguaPlan extends Plan {
+class UsarCanonDeAguaPlan extends Plan {
 
   @Override
   public void body() {
 
+    System.out.println("[PLAN] El tablero recibe petición de usar el cañón de agua");
+    CanonUsado cu = new CanonUsado();
+    
+    // Petición
+    IMessageEvent peticion = (IMessageEvent) getInitialEvent();
+
+    // Tablero
+    Tablero tablero = (Tablero) getBeliefbase().getBelief("tablero").getFact();
+
+    // Parámetros de la peticion
+    AgentIdentifier idJugador = (AgentIdentifier) peticion.getParameter("sender").getValue();
+
+    // Se encuentra en la lista de jugadores del tablero el jugador con id igual al de la petición
+    Jugador jugador = tablero.getJugador(idJugador);
+
+    // Casilla en la que está el jugador
+
+    boolean usado = false;
+
+    IMessageEvent msg = createMessageEvent("Inform_Usar_Canon");
+
+    if(jugador.subidoCamion() && (jugador.getPuntosAccion() > 4 || (jugador.getRol() == Jugador.Rol.CONDUCTOR && jugador.getPuntosAccion() > 2))){
+      
+      int posicionCanonX;
+      int posicionCanonY;
+
+      Casilla[][] mapa = tablero.getMapa();
+
+      if (jugador.getPosicion()[1] == 0) {
+        //Cuadrante de arriba-derecha
+        posicionCanonX = (int)(Math.random() * 4 + 5);// entre 5 y 8
+        posicionCanonY = (int)(Math.random() * 3 + 1);// entre 1 y 3
+        
+        Casilla[][] nuevoMapa = apagarAdyacentes(mapa, posicionCanonX, posicionCanonY);
+
+        tablero.setMapa(nuevoMapa);
+      }else if(jugador.getPosicion()[1] == mapa.length-1){
+        //Cuadrante de abajo-izquierda
+        posicionCanonX = (int)(Math.random() * 4 + 1);// entre 1 y 4
+        posicionCanonY = (int)(Math.random() * 3 + 4);// entre 4 y 6
+        
+        Casilla[][] nuevoMapa = apagarAdyacentes(mapa, posicionCanonX, posicionCanonY);
+
+        tablero.setMapa(nuevoMapa);
+      }else if(jugador.getPosicion()[0] == 0){
+        //Cuadrante de arriba-izquierda
+        posicionCanonX = (int)(Math.random() * 4 + 1);// entre 1 y 4
+        posicionCanonY = (int)(Math.random() * 3 + 1);// entre 1 y 3
+        
+        Casilla[][] nuevoMapa = apagarAdyacentes(mapa, posicionCanonX, posicionCanonY);
+
+        tablero.setMapa(nuevoMapa);
+      }else if(jugador.getPosicion()[0] == mapa[0].length-1){
+        //Cuadrante de abajo-derecha
+        posicionCanonX = (int)(Math.random() * 4 + 5);// entre 5 y 8
+        posicionCanonY = (int)(Math.random() * 3 + 4);// entre 4 y 6
+        
+        Casilla[][] nuevoMapa = apagarAdyacentes(mapa, posicionCanonX, posicionCanonY);
+
+        tablero.setMapa(nuevoMapa);
+      }else{
+        //debe se imposible
+      }
+
+      usado = true;
+    }
+
+    
+
+		if (!usado) {
+      msg = createMessageEvent("Refuse_Usar_Canon");
+      if(!jugador.subidoCamion()){
+        System.out.println("[RECHAZADO] tablero deniega peticion de usar cañon: el jugador no está subido al camión");
+      }
+      if(!(jugador.getPuntosAccion() > 4 || (jugador.getRol() == Jugador.Rol.CONDUCTOR && jugador.getPuntosAccion() > 2))){
+        System.out.println("[RECHAZADO] tablero deniega peticion de usar cañon: el jugador no tiene suficientes PA");
+      }
+    }else{
+      getBeliefbase().getBelief("tablero").setFact(tablero);
+      System.out.println("[INFO] tablero informa que se ha usado el cañon de agua");
+    }
+    
+    msg.setContent(cu);
+    msg.getParameterSet(SFipa.RECEIVERS).addValue(idJugador);
+    sendMessage(msg);
+
+  }
+
+
+  public Casilla[][] apagarAdyacentes(Casilla[][] mapa, int posX, int posY){
+
+    Casilla casilla = mapa[posY][posX];
+    Conexion[] conexiones =  casilla.getConexiones();
+
+    casilla.setTieneFuego(Casilla.Fuego.NADA);
+
+    //Casilla adyacente arriba
+    if(conexiones[0] == Casilla.Conexion.NADA || conexiones[0] == Casilla.Conexion.PUERTA_ABIERTA || conexiones[0] == Casilla.Conexion.PARED_ROTA){
+      mapa[posY-1][posX].setTieneFuego(Casilla.Fuego.NADA);
+    }
+    //Casilla adyacente abajo
+    if(conexiones[2] == Casilla.Conexion.NADA || conexiones[2] == Casilla.Conexion.PUERTA_ABIERTA || conexiones[2] == Casilla.Conexion.PARED_ROTA){
+      mapa[posY+1][posX].setTieneFuego(Casilla.Fuego.NADA);
+    }
+    //Casilla adyacente derecha
+    if(conexiones[1] == Casilla.Conexion.NADA || conexiones[1] == Casilla.Conexion.PUERTA_ABIERTA || conexiones[1] == Casilla.Conexion.PARED_ROTA){
+      mapa[posY][posX+1].setTieneFuego(Casilla.Fuego.NADA);
+    }
+    //Casilla adyacente izquierda
+    if(conexiones[3] == Casilla.Conexion.NADA || conexiones[3] == Casilla.Conexion.PUERTA_ABIERTA || conexiones[3] == Casilla.Conexion.PARED_ROTA){
+      mapa[posY][posX-1].setTieneFuego(Casilla.Fuego.NADA);
+    }
+
+    return mapa;
   }
 
 }

--- a/src/rescate/tablero/planes/UsarCannonDeAguaPlan.java
+++ b/src/rescate/tablero/planes/UsarCannonDeAguaPlan.java
@@ -11,13 +11,13 @@ import rescate.ontologia.conceptos.*;
 import rescate.ontologia.conceptos.Casilla.Conexion;
 import rescate.ontologia.predicados.*;
 
-class UsarCanonDeAguaPlan extends Plan {
+class UsarCannonDeAguaPlan extends Plan {
 
   @Override
   public void body() {
 
     System.out.println("[PLAN] El tablero recibe petición de usar el cañón de agua");
-    CanonUsado cu = new CanonUsado();
+    CannonUsado cu = new CannonUsado();
     
     // Petición
     IMessageEvent peticion = (IMessageEvent) getInitialEvent();

--- a/src/rescate/tablero/tablero.agent.xml
+++ b/src/rescate/tablero/tablero.agent.xml
@@ -808,7 +808,7 @@
         <value>SFipa.NUGGETS_XML</value>
       </parameter>
       <parameter name="content-class" class="Class" direction="fixed">
-        <value>CanonUsado.class</value>
+        <value>CannonUsado.class</value>
       </parameter>
     </messageevent>
 
@@ -820,7 +820,7 @@
         <value>SFipa.NUGGETS_XML</value>
       </parameter>
       <parameter name="content-class" class="Class" direction="fixed">
-        <value>CanonUsado.class</value>
+        <value>CannonUsado.class</value>
       </parameter>
     </messageevent>
 
@@ -832,7 +832,7 @@
         <value>SFipa.NUGGETS_XML</value>
       </parameter>
       <parameter name="content-class" class="Class" direction="fixed">
-        <value>CanonUsado.class</value>
+        <value>CannonUsado.class</value>
       </parameter>
     </messageevent>
 

--- a/src/rescate/tablero/tablero.agent.xml
+++ b/src/rescate/tablero/tablero.agent.xml
@@ -640,7 +640,52 @@
     </messageevent>
 
     <!-- Eliminar material peligrosa -->
-    <messageevent name="Request_Eliminar_materia_peligrosa" direction="send" type="fipa">
+    <messageevent name="Request_Eliminar_Materia_Peligrosa" direction="receive" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.REQUEST</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>EliminarMateriaPeligrosa.class</value>
+      </parameter>
+    </messageevent>
+
+    <messageevent name="Inform_Eliminar_Materia_Peligrosa" direction="send" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.INFORM</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>MateriaPeligrosaEliminada.class</value>
+      </parameter>
+    </messageevent>
+
+    <messageevent name="Refuse_Eliminar_Materia_Peligrosa" direction="send" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.REFUSE</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>MateriaPeligrosaEliminada.class</value>
+      </parameter>
+    </messageevent>
+
+    <messageevent name="Failure_Eliminar_Materia_Peligrosa" direction="send" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.FAILURE</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>MateriaPeligrosaEliminada.class</value>
+      </parameter>
     </messageevent>
 
     <!-- Identificar PDI -->
@@ -656,8 +701,54 @@
     </messageevent>
 
     <!-- Desplazar jugador -->
-    <messageevent name="Request_Desplazar" direction="send" type="fipa">
+    <messageevent name="Request_Desplazar" direction="receive" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.REQUEST</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>Desplazar.class</value>
+      </parameter>
     </messageevent>
+
+    <messageevent name="Inform_Desplazar" direction="send" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.INFORM</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>Desplazado.class</value>
+      </parameter>
+    </messageevent>
+
+    <messageevent name="Refuse_Desplazar" direction="send" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.REFUSE</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>Desplazar.class</value>
+      </parameter>
+    </messageevent>
+
+    <messageevent name="Failure_Desplazar" direction="send" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.FAILURE</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>Desplazar.class</value>
+      </parameter>
+    </messageevent>
+
 
     <!-- Unirse partida -->
     <messageevent name="Request_Unirse_Partida" direction="receive" type="fipa">
@@ -697,7 +788,52 @@
     </messageevent>
 
     <!-- Usar cannon de agua -->
-    <messageevent name="Request_Usar_cannon_Agua" direction="send" type="fipa">
+    <messageevent name="Request_Usar_Canon" direction="receive" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.REQUEST</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>UsarCannonAgua.class</value>
+      </parameter>
+    </messageevent>
+
+    <messageevent name="Inform_Usar_Canon" direction="send" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.INFORM</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>CanonUsado.class</value>
+      </parameter>
+    </messageevent>
+
+    <messageevent name="Refuse_Usar_Canon" direction="send" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.REFUSE</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>CanonUsado.class</value>
+      </parameter>
+    </messageevent>
+
+    <messageevent name="Failure_Usar_Canon" direction="send" type="fipa">
+      <parameter name="performative" class="String" direction="fixed">
+        <value>SFipa.FAILURE</value>
+      </parameter>
+      <parameter name="language" class="String" direction="fixed">
+        <value>SFipa.NUGGETS_XML</value>
+      </parameter>
+      <parameter name="content-class" class="Class" direction="fixed">
+        <value>CanonUsado.class</value>
+      </parameter>
     </messageevent>
 
   </events>


### PR DESCRIPTION
Dejo este commit sobre la nueva versión de develop, en la que hemos metido el plan de usar el cañon de agua, eliminar materia peligrosa e identificar punto de interes.

Las reglas dicen que un punto de interes se descubre cuando te mueves a una casilla que lo tiene, por lo que lo hemos implementado en el plan de mover jugador, hemos tenido que añadir dos estados al punto de interés que son VICTIMA_OCULTO y FALSA_ALARMA_OCULTO, porque no sabemos que hacer cuando el jugador simplemente se encuentra con un pdi OCULTO, y creemos que el tablero o la casilla debe saber lo que es en realidad ese punto de interés.